### PR TITLE
Avoid spaces in slurpy type constraint names

### DIFF
--- a/lib/MooseX/Types/Structured/OverflowHandler.pm
+++ b/lib/MooseX/Types/Structured/OverflowHandler.pm
@@ -14,7 +14,7 @@ has type_constraint => (
 
 sub name {
     my ($self) = @_;
-    return 'slurpy ' . $self->type_constraint->name;
+    return 'slurpy(' . $self->type_constraint->name . ')';
 }
 
 no Moose;

--- a/t/11-overflow.t
+++ b/t/11-overflow.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests=>12;
+use Test::More tests=>14;
 
 use MooseX::Types::Structured qw(Dict Tuple slurpy);
 use MooseX::Types::Moose qw(Int Str ArrayRef HashRef Object);
@@ -12,7 +12,9 @@ my $array_tailed_tuple =
         slurpy ArrayRef[Int],
      ];
 
-is($array_tailed_tuple->name, 'MooseX::Types::Structured::Tuple[Int,Str,slurpy ArrayRef[Int]]');
+is($array_tailed_tuple->name, 'MooseX::Types::Structured::Tuple[Int,Str,slurpy(ArrayRef[Int])]');
+is Moose::Util::TypeConstraints::find_or_create_type_constraint($array_tailed_tuple), $array_tailed_tuple,
+    'find_or_create_type_constraint finds array with slurpy';
 
 ok !$array_tailed_tuple->check(['ss',1]), 'correct fail';
 ok $array_tailed_tuple->check([1,'ss']), 'correct pass';
@@ -27,7 +29,9 @@ my $hash_tailed_dict =
       slurpy HashRef[Int],
     ];
 
-is($hash_tailed_dict->name, 'MooseX::Types::Structured::Dict[name,Str,age,Int,slurpy HashRef[Int]]');
+is($hash_tailed_dict->name, 'MooseX::Types::Structured::Dict[name,Str,age,Int,slurpy(HashRef[Int])]');
+is Moose::Util::TypeConstraints::find_or_create_type_constraint($hash_tailed_dict), $hash_tailed_dict,
+    'find_or_create_type_constraint finds hash with slurpy';
 
 ok !$hash_tailed_dict->check({name=>'john',age=>'napiorkowski'}), 'correct fail';
 ok $hash_tailed_dict->check({name=>'Vanessa Li', age=>35}), 'correct pass';


### PR DESCRIPTION
Moose::Util::TypeConstraints::find_or_create_type_constraint()
normalises the constraint name by removing spaces, so avoid them in the
type constraint name for slurpy Dicts and Tuples.

This fixes using native traits with slurpy constraints.
